### PR TITLE
fix: correct default route redirection after login

### DIFF
--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -54,9 +54,20 @@ const resolveDefaultRoute = () => {
 	const backendFallback = "/workbench"; // first menu path in backend menu DB
 	const frontendFallback = DEFAULT_PORTAL_ROUTE;
 
-	const rawDefaultRoute = env.VITE_APP_DEFAULT_ROUTE || (routerMode === "backend" ? backendFallback : frontendFallback);
 	const fallback = routerMode === "backend" ? backendFallback : frontendFallback;
-	return ensureLeadingSlash(rawDefaultRoute, fallback);
+	const rawDefaultRoute = env.VITE_APP_DEFAULT_ROUTE;
+	const normalizedRoute = removeTrailingSlash(ensureLeadingSlash(rawDefaultRoute ?? "", fallback));
+
+	if (routerMode !== "backend" && normalizedRoute === backendFallback) {
+		if (import.meta.env.DEV) {
+			console.warn(
+				`[global-config] "${normalizedRoute}" is reserved for backend routing. Falling back to "${frontendFallback}" in frontend mode.`,
+			);
+		}
+		return frontendFallback;
+	}
+
+	return normalizedRoute;
 };
 
 const resolvePublicPath = () => {

--- a/src/pages/sys/login/index.tsx
+++ b/src/pages/sys/login/index.tsx
@@ -16,8 +16,7 @@ function LoginPage() {
 	const bilingual = useBilingualText();
 
 	if (token.accessToken) {
-		const targetRoute = GLOBAL_CONFIG.routerMode === "backend" ? "/workbench" : GLOBAL_CONFIG.defaultRoute;
-		return <Navigate to={targetRoute} replace />;
+		return <Navigate to={GLOBAL_CONFIG.defaultRoute} replace />;
 	}
 
 	const brandLabel = bilingual("sys.login.brandName");

--- a/src/pages/sys/login/login-form.tsx
+++ b/src/pages/sys/login/login-form.tsx
@@ -44,8 +44,7 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
 		try {
 			await signIn({ ...values, username: trimmedUsername });
 			// 登录成功后跳转
-			const targetRoute = GLOBAL_CONFIG.routerMode === "backend" ? "/workbench" : GLOBAL_CONFIG.defaultRoute;
-			navigate(targetRoute, { replace: true });
+			navigate(GLOBAL_CONFIG.defaultRoute, { replace: true });
 			toast.success(bilingual("sys.login.loginSuccessTitle"), {
 				closeButton: true,
 			});


### PR DESCRIPTION
## Summary
- ensure the frontend default route never resolves to the backend-only `/workbench` path by normalising the configured value and falling back to the portal route when necessary
- simplify login redirect handling to rely on the resolved default route so successful sign-ins land on a valid page

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d3cb4d8ca8832aa07e1455dbd10f6c