### PR TITLE
fix: redesign portal feature views

### DIFF
--- a/src/pages/portal/types.ts
+++ b/src/pages/portal/types.ts
@@ -1,3 +1,8 @@
+import type { ComponentProps } from "react";
+
+import type { ButtonProps } from "@/ui/button";
+import type { Badge } from "@/ui/badge";
+
 export interface PortalMetric {
 	label: string;
 	value: string;
@@ -75,6 +80,45 @@ export interface PortalFeatureHero {
 	relatedProducts?: string[];
 }
 
+export interface PortalFeatureOperation {
+	label: string;
+	icon?: string;
+	variant?: ButtonProps["variant"];
+	size?: ButtonProps["size"];
+}
+
+export type PortalTableCellFormat = "text" | "badge" | "number" | "date";
+
+export interface PortalFeatureTableColumn {
+	key: string;
+	label: string;
+	format?: PortalTableCellFormat;
+	align?: "left" | "center" | "right";
+}
+
+export interface PortalFeatureTableRowAction {
+	label: string;
+	icon?: string;
+	variant?: ButtonProps["variant"];
+	tone?: "danger" | "default";
+}
+
+export interface PortalFeatureTableRow {
+	id: string;
+	values: Record<string, string>;
+	badges?: Partial<Record<string, ComponentProps<typeof Badge>["variant"]>>;
+	actions?: PortalFeatureTableRowAction[];
+}
+
+export interface PortalFeatureTable {
+	id: string;
+	title: string;
+	description?: string;
+	columns: PortalFeatureTableColumn[];
+	rows: PortalFeatureTableRow[];
+	actions?: PortalFeatureOperation[];
+}
+
 export interface PortalFeatureContent {
 	id: string;
 	hero: PortalFeatureHero;
@@ -86,4 +130,6 @@ export interface PortalFeatureContent {
 	risks?: PortalRisk[];
 	quickWins?: PortalQuickWin[];
 	insights?: PortalInsight[];
+	operations?: PortalFeatureOperation[];
+	tables?: PortalFeatureTable[];
 }


### PR DESCRIPTION
## Summary
- add operation and table metadata types so portal features can surface actionable menus
- render quick actions and data tables on portal feature pages to showcase CRUD-style workflows
- seed mock portal content with default operations and table rows for every menu entry

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d507c5be34832a90beb98eca67c159