### PR TITLE
fix: resolve portal feature lookup

### DIFF
--- a/src/routes/sections/dashboard/frontend.tsx
+++ b/src/routes/sections/dashboard/frontend.tsx
@@ -7,7 +7,7 @@ export function getFrontendDashboardRoutes(): RouteObject[] {
 	return PORTAL_NAV_SECTIONS.map((section) => {
 		const childRoutes = section.children.map<RouteObject>((child) => ({
 			path: child.path,
-			element: <PortalFeaturePage sectionKey={section.key} featureKey={child.key} />,
+			element: <PortalFeaturePage sectionKey={section.key} featureKey={child.path} />,
 		}));
 
 		if (!childRoutes.length) {


### PR DESCRIPTION
## Summary
- ensure portal feature routes use the path slug when looking up mock content so each page renders its dedicated data

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d50dd22bf8832a9609f1c07882a8e5